### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-name: compose craft
+name: compose-craft
 services:
   saas:
     image: composecraft/composecraft:latest


### PR DESCRIPTION
"name: compose craft" is not valid when using provided docker compose file, changed to "name: compose-craft"

<img width="790" alt="Screenshot 2025-01-30 at 21 39 40" src="https://github.com/user-attachments/assets/7eec8c5a-3119-4ce6-aac6-edab9d75a318" />
