### PR TITLE
Enhance UX by displaying all nodes on initial load of playground

### DIFF
--- a/components/playground/playground.tsx
+++ b/components/playground/playground.tsx
@@ -356,6 +356,7 @@ return (
         onConnect={onNodesConnect}
         onSelectionChange={handleSelection}
         onEdgesChange={handleSelection}
+        fitView
         //@ts-ignore
         onKeyDown={handleKeyPress}
         minZoom={Number.NEGATIVE_INFINITY}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "next-compose-craft",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Previously, only some nodes were shown on page load, which wasn’t very intuitive. I felt it would be better if all nodes were displayed immediately, so now they are.

